### PR TITLE
Kramdown Tweaks to promote correct numbering

### DIFF
--- a/pages/principles.md
+++ b/pages/principles.md
@@ -26,18 +26,19 @@ The following principles are intended to guide the development of a comprehensiv
 The mission of the Federal Data Strategy is to fully leverage the value of federal data for mission, service, and the public good by guiding the Federal Government in practicing ethical governance, conscious design, and learning culture.
 
 ### Ethical Governance
-
 1.  Uphold Ethics: Monitor and assess the implications of federal data practices for the public. Design checks and balances to protect and serve the public good. 
 2.  Exercise Responsibility: Practice effective data stewardship and governance. Employ sound data security practices, protect individual privacy, maintain promised confidentiality, and ensure appropriate access and use.  
 3.  Promote Transparency: Articulate the purposes and uses of federal data to engender public trust. Comprehensively document processes and products to inform data providers and users. 
 
 ### Conscious Design
+{:start="4"}
 4.  Ensure Relevance: Protect the quality and integrity of the data. Validate that data are appropriate, accurate, objective, accessible, useful, understandable, and timely. 
 5.  Harness Existing Data: Identify data needs to inform priority research and policy questions; reuse data if possible and acquire additional data if needed. 
 6.  Anticipate Future Uses: Create data thoughtfully, considering fitness for use by others; plan for reuse and build in interoperability from the start. 
 7.  Demonstrate Responsiveness: Improve data collection, analysis, and dissemination with ongoing input from users and stakeholders. The feedback process is cyclical; establish a baseline, gain support, collaborate, and refine continuously.
 
 ### Learning Culture
+{:start="8"}
 8.  Invest in Learning: Promote a culture of continuous and collaborative learning with and about data through ongoing investment in data infrastructure and human resources. 
 9.  Develop Data Leaders: Cultivate data leadership at all levels of the federal workforce by investing in training and development about the value of data for mission, service, and the public good.
 10. Practice Accountability: Assign responsibility, audit data practices, document and learn from results, and make needed changes.


### PR DESCRIPTION
the principles should have an absolute number 1-10 vs. starting over a 1 for each of the headings (Ethical, Conscious, Learning)