### PR TITLE
Update cdo-council-membership-status.csv

### DIFF
--- a/data/cdo-council-membership-status.csv
+++ b/data/cdo-council-membership-status.csv
@@ -1,7 +1,7 @@
 AGENCY,CFO Act agency? (Y/N),Does an [agency].gov/data web page exist? (Y/N),Did an agency post DGB to [agency].gov/data web page? (Y/N),Membership? (Y/N),Charter?(Y/N),Meeting cadence? (Y/N)
 Consumer Financial Protection Bureau,N,Y,Y,Y,Y,Y
 Department of Agriculture,Y,Y,Y,N,Y,N
-Department of Commerce,Y,Y,Y,Y,Y,N
+Department of Commerce,Y,Y,Y,Y,Y,Y
 Department of Education,Y,Y,Y,Y,Y,Y
 Department of Justice,Y,Y,Y,Y,Y,N
 Department of Labor,Y,Y,Y,Y,Y,N

--- a/data/cdo-council-membership-status.csv
+++ b/data/cdo-council-membership-status.csv
@@ -3,7 +3,7 @@ Consumer Financial Protection Bureau,N,Y,Y,Y,Y,Y
 Department of Agriculture,Y,Y,Y,N,Y,N
 Department of Commerce,Y,Y,Y,Y,Y,Y
 Department of Education,Y,Y,Y,Y,Y,Y
-Department of Justice,Y,Y,Y,Y,Y,N
+Department of Justice,Y,Y,Y,Y,Y,Y
 Department of Labor,Y,Y,Y,Y,Y,N
 Department of the Interior,Y,Y,Y,Y,Y,N
 Department of the Treasury,Y,N,Y,Y,Y,N


### PR DESCRIPTION
From DOC's /data page: "The Commerce Data Governance Board (CDGB) was established and first met in September 2019. The CDGB is the Department’s data governance and coordination body, and is chaired by the Commerce Chief Data Officer, with representatives from all Bureaus. The CDGB Terms of Reference were approved by its members in December 2019, and *the body meets monthly to coordinate the management of Commerce data as an asset*."