### PR TITLE
Adding reference to AI R&D data and code tagging

### DIFF
--- a/pages/action-plan.md
+++ b/pages/action-plan.md
@@ -143,7 +143,7 @@ By July 2020, all agencies will update existing comprehensive data inventories i
 
 | Milestone                                                                                      | Measurement                   | Target Date                                    | Reporting Mechanism          | Required or Encouraged    |
 |------------------------------------------------------------------------------------------------|-------------------------------|------------------------------------------------|------------------------------|---------------------------|
-| Update comprehensive data inventories for overall completeness and priority <b>COVID-19 response*</b> data asset sprints | Metadata quality improvements | Minimally every 3 months, as often as possible | Agency public data.json APIs | Required for all agencies |
+| Update comprehensive data inventories for overall completeness, AI R&D [^22] and priority <b>COVID-19 response*</b> data asset sprints | Metadata quality improvements | Minimally every 3 months, as often as possible | Agency public data.json APIs | Required for all agencies |
 | Update comprehensive data inventory to conform to standard metadata                            | Completion                    | <s>July 31, 2020</s> <b>90 days after OMB/GSA standard metadata guidance is issued*</b>                             | Agency public data.json APIs | Required for all agencies 
 
 &#42; *Due to government-wide focus on COVID-19 response activities, the Federal Data Strategy team has included COVID-19 response data assets as priority data assets for this milestone and clarified target dates based on OMB guidance dependencies. Read the team's statement on our [News]({{ site.baseurl }}/news) page.*
@@ -411,3 +411,4 @@ Future annual Action Plans will build on the 2020 Action Plan to further develop
 [^19]: See Report on Statistical Disclosure Limitation Methodology available at: [nces.ed.gov/FCSM/pdf/spwp22.pdf](https://nces.ed.gov/FCSM/pdf/spwp22.pdf)
 [^20]: 44 U.S.C. §3501 et seq.
 [^21]: Government-wide metadata standards are available at [resources.data.gov](https://resources.data.gov)
+[^22]: Implementation Guidance to Federal Agencies Regarding Enterprise Data and Source Code Inventories at [code.gov](https://code.gov/assets/data/ai_inventory-guidance.pdf)


### PR DESCRIPTION
I suggest adding a reference to the implementation guidance for how to identify AI R&D data sets and source code in agency data.json and code.json files. This activity is referenced in Action 5 and Action 8. 

I think adding this specific guidance on which schema elements to use (keyword in data.json and tags in code.json) with the suggested values "usg-artificial-intelligence","usg-ai-training-data","usg-ai-testing-data" will reduce the effort for agencies to label data and code, and increase the accuracy of data and code catalogs.

There's already a reference to [Executive Order on Maintaining American Leadership in Artificial Intelligence (2019)](https://www.whitehouse.gov/presidential-actions/executive-order-maintaining-american-leadership-artificial-intelligence/), so adding this specific implementation guide will save agencies from having to search out what specific tags to use.