### PR TITLE
Fix code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/assets/uswds/js/uswds.js
+++ b/assets/uswds/js/uswds.js
@@ -1209,7 +1209,7 @@ var trim = String.prototype.trim ? function (str) {
 };
 
 var queryById = function queryById(id) {
-  return this.querySelector('[id="' + id.replace(/"/g, '\\"') + '"]');
+  return this.querySelector('[id="' + id.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"]');
 };
 
 module.exports = function resolveIds(ids, doc) {


### PR DESCRIPTION
Fixes [https://github.com/GSA/data-strategy/security/code-scanning/1](https://github.com/GSA/data-strategy/security/code-scanning/1)

To fix the problem, we need to ensure that backslashes in the `id` variable are properly escaped before it is used in the query selector. This can be done by modifying the `id.replace` method to also escape backslashes. We will use a regular expression with the global flag to replace all occurrences of backslashes and double quotes.

- Modify the `id.replace` method on line 1212 to escape both backslashes and double quotes.
- Ensure that the regular expression used in the `replace` method includes the global flag to replace all occurrences.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
